### PR TITLE
Change h3 -> h2 preview  in perference.xhtml

### DIFF
--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -179,7 +179,7 @@
     </hbox>
     <hbox align="center">
       <html:label>
-        <html:h2 data-l10n-id="pref-preview-authors" />
+        <html:h3 data-l10n-id="pref-preview-authors" />
       </html:label>
       <html:label id="zotero-prefpane-__addonRef__-authors-format-preview" />
     </hbox>


### PR DESCRIPTION
Resolve the title misalignment issue shown in the image below:

![image](https://github.com/github-young/zotero-better-authors/assets/44738481/c3ca4b9e-52cc-494b-8e4c-b48036ef8f90)
