### PR TITLE
fix(columns): resolve creator types dynamically per item

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ This is a simple plugin for [Zotero](https://www.zotero.org/) 7. See this [annou
   - Customize the symbol(s) to separate authors (either in one author or between authors, _e. g._ `,` `;` ` `), and to indicate the last author (_e. g._ `*` `†` `‡` `⸸`)
   - Choose the name orders for displaying authors: `Firstname Lastname`, `Lastname Firstname`, or `auto (according to the language of the authors names)`
 
+> [!NOTE]
+> The First Author / Last Author / Authors List columns follow each item's primary creator type. For most items this is `author`; for presentations it is `presenter`, for patents `inventor`, for films/videos `director`, and so on. Theses are a special case: the Last Author column shows the first non-author creator (typically the advisor).
+
 ## Usage & Screenshots
 
 This plugin comes with a self-explanatory settings panel in Zotero 7 settings. An example of the displayed authors and corresponding settings (with English and Chinese support) is given in the screenshot.

--- a/src/modules/betterAuthors.ts
+++ b/src/modules/betterAuthors.ts
@@ -132,12 +132,11 @@ export class UIBetterAuthorsFactory {
 
   static displayCreators(
     creators: _ZoteroTypes.Item.Creator[],
-    filterType: string = "author",
+    filterTypeID: number,
   ) {
-    // Only get all authors in the creators
+    // Keep only creators matching the requested type
     const authors = creators.filter(
-      (creator) =>
-        creator.creatorTypeID === Zotero.CreatorTypes.getID(filterType),
+      (creator) => creator.creatorTypeID === filterTypeID,
     );
     if (authors.length == 0) return "";
     // const sep = this.getSeparator("sep");
@@ -254,10 +253,15 @@ export class UIBetterAuthorsFactory {
       ): string => {
         if (!(item instanceof Zotero.Item)) return "";
         const creators = item.getCreators();
-        const authorTypeID = Zotero.CreatorTypes.getID("author");
-        // Only get all authors in the creators
+        const primaryTypeID =
+          Zotero.CreatorTypes.getPrimaryIDForType(item.itemTypeID) ||
+          Zotero.CreatorTypes.getID("author");
+        if (!primaryTypeID) return "";
+        // Keep only creators of the item type's primary creator type
+        // (author for journal articles, presenter for presentations,
+        // inventor for patents, director for films, ...)
         const authors = creators.filter(
-          (creator) => creator.creatorTypeID === authorTypeID,
+          (creator) => creator.creatorTypeID === primaryTypeID,
         );
         if (authors.length == 0) return "";
         const sepIntra = getPref("sep-intra-author");
@@ -293,11 +297,12 @@ export class UIBetterAuthorsFactory {
         if (!(item instanceof Zotero.Item)) return "";
         const creators = item.getCreators();
         const itemType = item.itemType;
-        const authorTypeID = Zotero.CreatorTypes.getID("author");
         let lastAuthorDisplayed: string = "";
 
         if (itemType === "thesis") {
-          // Get the first contributor for thesis
+          // Thesis convention: the "last author" position shows the
+          // advisor — i.e. the first non-author creator on the item.
+          const authorTypeID = Zotero.CreatorTypes.getID("author");
           const contributors = creators.filter(
             (creator) => creator.creatorTypeID !== authorTypeID,
           );
@@ -312,9 +317,13 @@ export class UIBetterAuthorsFactory {
             );
           }
         } else {
-          // Only get all authors in the creators
+          // Keep only creators of the item type's primary creator type
+          const primaryTypeID =
+            Zotero.CreatorTypes.getPrimaryIDForType(item.itemTypeID) ||
+            Zotero.CreatorTypes.getID("author");
+          if (!primaryTypeID) return "";
           const authors = creators.filter(
-            (creator) => creator.creatorTypeID === authorTypeID,
+            (creator) => creator.creatorTypeID === primaryTypeID,
           );
           if (authors.length > 0) {
             const sepIntra = getPref("sep-intra-author");
@@ -352,7 +361,11 @@ export class UIBetterAuthorsFactory {
       ): string => {
         if (!(item instanceof Zotero.Item)) return "";
         const creators = item.getCreators();
-        return this.displayCreators(creators);
+        const primaryTypeID =
+          Zotero.CreatorTypes.getPrimaryIDForType(item.itemTypeID) ||
+          Zotero.CreatorTypes.getID("author");
+        if (!primaryTypeID) return "";
+        return this.displayCreators(creators, primaryTypeID);
       },
       renderCell(index: number, data: string, column) {
         const span = Zotero.getMainWindow().document.createElementNS(

--- a/src/modules/betterAuthors.ts
+++ b/src/modules/betterAuthors.ts
@@ -254,9 +254,10 @@ export class UIBetterAuthorsFactory {
       ): string => {
         if (!(item instanceof Zotero.Item)) return "";
         const creators = item.getCreators();
+        const authorTypeID = Zotero.CreatorTypes.getID("author");
         // Only get all authors in the creators
         const authors = creators.filter(
-          (creator) => creator.creatorTypeID === 8,
+          (creator) => creator.creatorTypeID === authorTypeID,
         );
         if (authors.length == 0) return "";
         const sepIntra = getPref("sep-intra-author");
@@ -292,12 +293,13 @@ export class UIBetterAuthorsFactory {
         if (!(item instanceof Zotero.Item)) return "";
         const creators = item.getCreators();
         const itemType = item.itemType;
+        const authorTypeID = Zotero.CreatorTypes.getID("author");
         let lastAuthorDisplayed: string = "";
 
         if (itemType === "thesis") {
           // Get the first contributor for thesis
           const contributors = creators.filter(
-            (creator) => creator.creatorTypeID !== 8,
+            (creator) => creator.creatorTypeID !== authorTypeID,
           );
           if (contributors.length > 0) {
             const sepIntra = getPref("sep-intra-author");
@@ -312,7 +314,7 @@ export class UIBetterAuthorsFactory {
         } else {
           // Only get all authors in the creators
           const authors = creators.filter(
-            (creator) => creator.creatorTypeID === 8,
+            (creator) => creator.creatorTypeID === authorTypeID,
           );
           if (authors.length > 0) {
             const sepIntra = getPref("sep-intra-author");

--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -38,27 +38,30 @@ function initPreferencesUI() {
 }
 
 function updatePreview() {
+  const authorTypeID = Zotero.CreatorTypes.getID(
+    "author",
+  ) as _ZoteroTypes.Item.Creator["creatorTypeID"];
   const exampleAuthorList: _ZoteroTypes.Item.Creator[] = [
     {
-      creatorTypeID: 8,
+      creatorTypeID: authorTypeID,
       fieldMode: 0,
       firstName: "Alice",
       lastName: "Adams",
     },
     {
-      creatorTypeID: 8,
+      creatorTypeID: authorTypeID,
       fieldMode: 0,
       firstName: "Bob",
       lastName: "Brown",
     },
     {
-      creatorTypeID: 8,
+      creatorTypeID: authorTypeID,
       fieldMode: 0,
       firstName: "三",
       lastName: "张",
     },
     {
-      creatorTypeID: 8,
+      creatorTypeID: authorTypeID,
       fieldMode: 0,
       firstName: "四",
       lastName: "李",

--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -68,7 +68,10 @@ function updatePreview() {
     },
   ];
 
-  const example = UIBetterAuthorsFactory.displayCreators(exampleAuthorList);
+  const example = UIBetterAuthorsFactory.displayCreators(
+    exampleAuthorList,
+    authorTypeID,
+  );
   const previewElement = addon.data.prefs?.window.document.getElementById(
     `zotero-prefpane-${config.addonRef}-authors-format-preview`,
   );


### PR DESCRIPTION
## Summary

Fixes #188. Also resolves #182 (Authors List empty for presentations) and #114 (First Author empty for patents). Three commits, all addressing the same root cause family: the columns hardcoded `creator.creatorTypeID === 8` and the literal `"author"` as the only creator type the plugin would surface.

## The bugs

**#188 — wrong literal for "author".** `creatorTypes.creatorTypeID` is assigned at first launch and the schema has shifted between Zotero versions. On current installs:

```sql
SELECT creatorTypeID, creatorType FROM creatorTypes WHERE creatorTypeID IN (8, 10);
-- 8  | sponsor
-- 10 | author
```

So the First/Last Author columns were filtering for *sponsors* on most users' libraries and rendering empty, while the Authors List column (which already used `Zotero.CreatorTypes.getID`) worked correctly.

**#182 / #114 — no resolution by item type.** Even after fixing the literal, the columns only ever surfaced creators whose type is `author`. Presentations (whose primary creator type is `presenter`), patents (`inventor`), films (`director`), computer programs (`programmer`), interviews (`interviewee`), maps (`cartographer`), podcasts (`podcaster`), etc., showed empty cells.

## Changes

Three commits:

1. **`fix(columns): use Zotero.CreatorTypes.getID for author filters`** — `src/modules/betterAuthors.ts`. Replace the three integer literals in the column dataProviders with `Zotero.CreatorTypes.getID("author")` cached once per dataProvider invocation. Mirrors the existing pattern in `displayCreators`.

2. **`fix(preferences): use Zotero.CreatorTypes.getID for preview author data`** — `src/modules/preferenceScript.ts`. The preferences-pane preview built its example creators with the literal `creatorTypeID: 8`, then passed them through the (already-correct) `displayCreators` filter. On current installs the preview was therefore empty for the same reason as the columns.

3. **`fix(columns): resolve primary creator type per item type`** — generalizes the fix to resolve the *primary creator type* for each item via `Zotero.CreatorTypes.getPrimaryIDForType(item.itemTypeID)`, with `"author"` as the fallback when no primary is defined. Items whose primary type is `author` behave exactly as before; items whose primary is e.g. `presenter` or `inventor` now show that creator instead of nothing. The thesis special case (Last Author = first non-author creator = advisor) is preserved. `displayCreators` signature changes from `(creators, filterType: string = "author")` to `(creators, filterTypeID: number)` so the column dataProviders can hand it a numeric type ID directly. The one non-column caller (the preferences preview) is updated to pass the author type ID explicitly.

## Behavior matrix

| Item type | "First Author" today | After PR |
|---|---|---|
| journalArticle, book, report, … (primary = author) | first author ✓ | first author (unchanged) |
| thesis | empty / single-author shown | unchanged (Last Author still shows advisor) |
| presentation | empty | first presenter |
| patent | empty | first inventor |
| film / videoRecording / tvBroadcast | empty | director |
| computerProgram | empty | first programmer |
| interview | empty | first interviewee |
| map | empty | first cartographer |
| podcast | empty | first podcaster |

Column labels (`First Author` / `Last Author` / `Authors List`) are unchanged. The labels are slightly imprecise on non-author item types but the cells go from empty to informative. README adds a short note about the per-item-type behavior.

## Test plan

- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm exec eslint src/` passes
- [x] `grep -rn "creatorTypeID" src/` shows no integer literals remain
- [x] Manual: install the built `.xpi` in current Zotero with a library containing journalArticles, presentations, and patents; confirm First / Last / Authors List columns populate appropriately for each