### PR TITLE
support Zotero V10

### DIFF
--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -14,7 +14,7 @@
       "id": "__addonID__",
       "update_url": "__updateURL__",
       "strict_min_version": "6.999",
-      "strict_max_version": "9.*"
+      "strict_max_version": "10.999.*"
     }
   }
 }


### PR DESCRIPTION
Update `strict_max_version` to `10.999.*` to support Zotero 10.

Tested with Zotero 10.0 on Windows 11. The custom author columns and preferences work as expected.